### PR TITLE
Dockerizing the npmE service that installs, starts, stops the server.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM    centos:centos7
+MAINTAINER Marcello de Sales (marcello_desales@intuit.com)
+
+## RHEL/CentOS 7 64-Bit ##
+RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/beta/7/x86_64/epel-release-7-1.noarch.rpm
+
+# Default programs + Install Node.js and npm
+RUN yum install -y git nodejs npm --enablerepo=epel
+
+# upgrade npm to 2.x.x on the VM you have provisioned:
+RUN npm install npm@2.0.0-beta.3 -g
+
+# Create non-root user npm Enterprise must be installed from an account that has passwordless sudo
+RUN /usr/sbin/useradd --create-home --shell /bin/bash npme && echo 'root:admin' | chpasswd && \
+    mkdir -p /.config/configstore /.local /.cache /.npm && chown -R npme /.npm /usr/lib /.config /.local /.cache
+
+RUN npm install npme -g
+
+# Set the username which is to run the container based on the image being built.
+USER npme
+
+ENTRYPOINT ["npme"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
+# Docker Image for the npm Enterprise Installer
+
+sudo docker run -ti marcellodesales/npme
+
+```
+$ sudo docker run -t -i marcellodesales/npme 
+npm Enterprise. It's npm, but you run it yourself!
+
+install:	install npm Enterprise on a (preferably) blank operating system.
+start:		start npmE and all its services.
+stop:		stop npmE services.
+restart:	restart npmE services.
+add-package:	add a package to the package-follower whitelist (add-package jquery).
+reset-follower:	reindex from the public registry all packages listed in whitelist.
+update:		update npm Enteprise.
+
+Options:
+  -u, --user   [default: "npme"]
+  -g, --group  [default: "npme"]
+  -s, --sudo   [default: true]
+
+```
+
+You need to install and obtain a license.
+
+```
+$ sudo docker run -t -i marcellodesales/npme install
+[?] this will install npmE on this server (you should only run this on a dedicated machine), continue? Yes
+[?] enter your billing email: example@mail.com
+[?] enter your license key: @#!@34%$@#
+
+```
+
+The manual steps are described below:
+
 # npm Enterprise Installer
 
 One-step-installer for npmE servers.


### PR DESCRIPTION
This commit adds support for the Dockerfile that serves the dockerized
application found in the forked repo. In order to use this container,
use the README.md for instructions. This image is distributed on the
DockerHub portal at https://registry.hub.docker.com/u/marcellodesales/npme/
-   new file:   Dockerfile
- The dockerfile that builds the requirements defined in the npme/npme
  documentation on Github.
-   modified:   README.md
- Adding examples and documentation on how to run this using Docker.
