### PR TITLE
ln -s --force > ln -sf

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ module.exports = function(args) {
       });
     },
     function(next) {
-      var command = 'ln -s --force ' + path.resolve('../.bin/npme') + ' /usr/bin/npme';
+      var command = 'ln -sf ' + path.resolve('../.bin/npme') + ' /usr/bin/npme';
 
       if (sudo) command = 'sudo ' + command;
 


### PR DESCRIPTION
Just FYI `--force` is not supported on OS X, but `-f` is. Go figure. 
May also be an issue on other platforms.
Ideally use node apis or something like `fs-symlink`.
