### PR TITLE
expose the license management module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ var async = require('async'),
   Platform = require('./platform'),
   util = new (require('../lib/util'))();
 
-module.exports = function(args) {
+
+var npme = function(args) {
   var license = new License(),
     sudo = true,
     user = args.user || 'npme',
@@ -57,3 +58,7 @@ module.exports = function(args) {
     if (err) logger.error(error.message);
   });
 };
+
+npme.License = License;
+
+module.exports = npme;


### PR DESCRIPTION
I'd like to use the license management logic in other npme tools, by exposing the class I can avoid repeating logic.
