### PR TITLE
feat: check for newer npme version via update-notifier

### DIFF
--- a/bin/npme.js
+++ b/bin/npme.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+require('../lib/check-for-update')()
 var chalk = require('chalk')
 
 require('yargs')

--- a/bin/npme.js
+++ b/bin/npme.js
@@ -1,261 +1,31 @@
 #!/usr/bin/env node
 
-var adminCommand = 'replicated admin '
 var chalk = require('chalk')
-var fs = require('fs')
-var path = require('path')
-var publicIp = require('public-ip')
-var request = require('request')
-var spawn = require('child_process').spawn
-var cwd = path.resolve(__dirname, '../')
 
 require('yargs')
   .usage('$0 [command] [arguments]')
-  .help('h')
-  .alias('h', 'help')
-  .command('install', 'install the npm Enterprise appliance', install)
-  .command('ssh', 'ssh into the npm Enterprise appliance', ssh)
-  .command('add-package', 'add a package to your whitelist', addPackage)
-  .command('remove-package', 'remove a package from your registry', removePackage)
-  .command('reset-follower', 'reset the public registry follower', resetFollower)
-  .command('update-license', 'update the license associated with your npm Enterprise appliance', updateLicense)
-  .command('manage-tokens', 'manage npm Enterprise deploy tokens', manageTokens)
-  .command('edit-homepage', 'edit the packages displayed on the npme homepage', editHomepage)
-  .command('addon', 'install a third-party addon', addon)
-  .version(require('../package').version, 'v')
-  .alias('v', 'version')
-  .option('sudo', {
-    alias: 's',
+  .command(require('../cmd/install'))
+  .command(require('../cmd/ssh'))
+  .command(require('../cmd/add-package'))
+  .command(require('../cmd/remove-package'))
+  .command(require('../cmd/reset-follower'))
+  .command(require('../cmd/update-license'))
+  .command(require('../cmd/manage-tokens'))
+  .command(require('../cmd/edit-homepage'))
+  .command(require('../cmd/addon'))
+  .option('s', {
+    alias: 'sudo',
     description: 'should shell commands be run as sudo user',
     boolean: true,
-    default: true
+    default: true,
+    global: true
   })
-  .option('release', {
-    alias: 'r',
-    description: 'what release of replicated should be used (defaults to stable)'
-  })
+  .help().alias('h', 'help')
+  .version().alias('v', 'version')
   .example('$0 add-package lodash', 'add the lodash package to your whitelist')
   .demand(1, 'you must provide a command to run')
+  .wrap(88)
   .argv
-
-// install the replicated appliance.
-function install (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('install a brand new npm Enterprise appliance')
-    .argv
-
-  exec('cp replicated-license-retrieval.json /etc', argv.sudo, function () {
-    var release = argv.release ? '/' + argv.release : ''
-
-    request.get('https://get.replicated.com' + release, function (err, res, content) {
-      if (err) {
-        console.log(chalk.red(err.message))
-        return
-      }
-
-      fs.writeFileSync(path.resolve(cwd, './install.sh'), content, 'utf-8')
-
-      exec('sh install.sh', argv.sudo, function (code) {
-        if (code !== 0) {
-          console.log(chalk.bold.red('oh no! something went wrong during the install...\r\n') +
-            chalk.bold.red('contact ') +
-            chalk.bold.green('support@npmjs.com ') +
-            chalk.bold.red('and we can help get you up and running'))
-        } else {
-          exec('mkdir -p /etc/replicated/brand/', argv.sudo, function () {
-            exec('cp -f brand.css /etc/replicated/brand/brand.css', argv.sudo, function () {})
-          })
-
-          console.log(chalk.bold.green('Congrats! Your npm Enterprise server is now up and running \\o/'))
-          console.log(chalk.bold('\nThere are just a few final steps:\n'))
-
-          publicIp.v4(function (err, ip) {
-            var accessMessage
-
-            if (err) {
-              accessMessage = 'Access this server in a web-browser via port 8800 (this will bring you to an admin console)'
-            } else {
-              accessMessage = 'Access this server in a web-browser at https://' + ip + ':8800 (this will bring you to an admin console)'
-            }
-
-            ;[
-              accessMessage,
-              'Proceed passed the HTTPS connection security warning (a self-signed cert is being used initially)',
-              'Upload a custom TLS/SSL cert/key or proceed with the provided self-signed pair.',
-              'Configure your npm instance & click "Save".',
-              'Visit https://docs.npmjs.com/, for information about using npm Enterprise or contact support@npmjs.com'
-            ].forEach(function (s, i) {
-              console.log(chalk.bold('Step ' + (i + 1) + '.') + ' ' + s)
-            })
-          })
-        }
-      })
-    })
-  })
-}
-
-function addPackage (yargs) {
-  var argv = yargs
-    .usage('$0 package-name[@version]')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog("add a new package to your appliance's whitelist")
-    .argv
-
-  var cmd = adminCommand + argv._.join(' ')
-  if (~cmd.indexOf('@')) cmd += ' --all-versions=false'
-  exec(cmd, argv.sudo, function () {})
-}
-
-function removePackage (yargs) {
-  var argv = yargs
-    .usage('$0 package-name')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('remove a package from your registry')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function resetFollower (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('reset the sequence # of the public registry follower')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function updateLicense (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('update the license on your npm Enterprise appliance')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function manageTokens (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('manage the tokens on your npm Enterprise appliance')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function editHomepage (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('edit the packages displayed on the npme homepage')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function addon (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('install a third-party addon')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function ssh (yargs) {
-  var argv = yargs
-    .usage('$0')
-    .option('sudo', {
-      alias: 's',
-      description: 'should shell commands be run as sudo user',
-      boolean: true,
-      default: true
-    })
-    .help('h')
-    .alias('h', 'help')
-    .epilog('ssh into the npm Enterprise appliance')
-    .argv
-
-  exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
-}
-
-function exec (command, sudo, cb) {
-  var commands = ['-c']
-  if (sudo) command = 'sudo -E ' + command
-  commands.push(command)
-
-  var proc = spawn('sh', commands, {
-    cwd: cwd,
-    env: process.env,
-    stdio: 'inherit'
-  })
-
-  proc.on('close', function (code) {
-    cb(code)
-  })
-}
 
 process.on('uncaughtException', function (err) {
   // if there is no Internet connection

--- a/cmd/add-package.js
+++ b/cmd/add-package.js
@@ -1,0 +1,22 @@
+var utils = require('../lib/utils')
+
+var adminCommand = utils.adminCommand
+var exec = utils.exec
+var command = utils.command(__filename)
+
+var cmd = {
+  command: command,
+  desc: 'add a package to your whitelist',
+  usage: '$0 ' + command + ' package-name[@version] -- [opts]',
+  demand: 1,
+  demandDesc: 'you must provide a package name and optional version',
+  epilog: 'add a new package to your appliance\'s whitelist'
+}
+
+cmd.handler = function (argv) {
+  var cmd = adminCommand + argv._.join(' ')
+  if (~cmd.indexOf('@')) cmd += ' --all-versions=false'
+  exec(cmd, argv.sudo, function () {})
+}
+
+module.exports = utils.decorate(cmd)

--- a/cmd/addon.js
+++ b/cmd/addon.js
@@ -1,0 +1,13 @@
+var utils = require('../lib/utils')
+
+var command = utils.command(__filename)
+
+var cmd = {
+  command: command,
+  desc: 'install a third-party addon',
+  usage: '$0 ' + command + ' <addon> -- [opts]',
+  demand: 1,
+  demandDesc: 'you must specify an addon to install'
+}
+
+module.exports = utils.decorate(cmd)

--- a/cmd/edit-homepage.js
+++ b/cmd/edit-homepage.js
@@ -1,0 +1,11 @@
+var utils = require('../lib/utils')
+
+var command = utils.command(__filename)
+
+var cmd = {
+  command: command,
+  desc: 'edit the packages displayed on the npme homepage',
+  usage: '$0 ' + command + ' <command>'
+}
+
+module.exports = utils.decorate(cmd)

--- a/cmd/install.js
+++ b/cmd/install.js
@@ -1,0 +1,74 @@
+var chalk = require('chalk')
+var fs = require('fs')
+var path = require('path')
+var publicIp = require('public-ip')
+var request = require('request')
+var utils = require('../lib/utils')
+
+var cwd = utils.cwd
+var exec = utils.exec
+
+var cmd = {
+  desc: 'install the npm Enterprise appliance',
+  options: {
+    r: {
+      alias: 'release',
+      description: 'what release of replicated should be used (defaults to stable)',
+      type: 'string'
+    }
+  },
+  epilog: 'install a brand new npm Enterprise appliance'
+}
+
+cmd.handler = function (argv) {
+  exec('cp replicated-license-retrieval.json /etc', argv.sudo, function () {
+    var release = argv.release ? '/' + argv.release : ''
+
+    request.get('https://get.replicated.com' + release, function (err, res, content) {
+      if (err) {
+        console.log(chalk.red(err.message))
+        return
+      }
+
+      fs.writeFileSync(path.resolve(cwd, './install.sh'), content, 'utf-8')
+
+      exec('sh install.sh', argv.sudo, function (code) {
+        if (code !== 0) {
+          console.log(chalk.bold.red('oh no! something went wrong during the install...\r\n') +
+            chalk.bold.red('contact ') +
+            chalk.bold.green('support@npmjs.com ') +
+            chalk.bold.red('and we can help get you up and running'))
+        } else {
+          exec('mkdir -p /etc/replicated/brand/', argv.sudo, function () {
+            exec('cp -f brand.css /etc/replicated/brand/brand.css', argv.sudo, function () {})
+          })
+
+          console.log(chalk.bold.green('Congrats! Your npm Enterprise server is now up and running \\o/'))
+          console.log(chalk.bold('\nThere are just a few final steps:\n'))
+
+          publicIp.v4(function (err, ip) {
+            var accessMessage
+
+            if (err) {
+              accessMessage = 'Access this server in a web-browser via port 8800 (this will bring you to an admin console)'
+            } else {
+              accessMessage = 'Access this server in a web-browser at https://' + ip + ':8800 (this will bring you to an admin console)'
+            }
+
+            ;[
+              accessMessage,
+              'Proceed passed the HTTPS connection security warning (a self-signed cert is being used initially)',
+              'Upload a custom TLS/SSL cert/key or proceed with the provided self-signed pair.',
+              'Configure your npm instance & click "Save".',
+              'Visit https://docs.npmjs.com/, for information about using npm Enterprise or contact support@npmjs.com'
+            ].forEach(function (s, i) {
+              console.log(chalk.bold('Step ' + (i + 1) + '.') + ' ' + s)
+            })
+          })
+        }
+      })
+    })
+  })
+}
+
+module.exports = utils.decorate(cmd, __filename)

--- a/cmd/manage-tokens.js
+++ b/cmd/manage-tokens.js
@@ -1,0 +1,12 @@
+var utils = require('../lib/utils')
+
+var command = utils.command(__filename)
+
+var cmd = {
+  command: command,
+  desc: 'manage npm Enterprise deploy tokens',
+  usage: '$0 ' + command + ' <command> -- [opts]',
+  epilog: 'manage the tokens on your npm Enterprise appliance'
+}
+
+module.exports = utils.decorate(cmd)

--- a/cmd/remove-package.js
+++ b/cmd/remove-package.js
@@ -1,0 +1,13 @@
+var utils = require('../lib/utils')
+
+var command = utils.command(__filename)
+
+var cmd = {
+  command: command,
+  desc: 'remove a package from your registry',
+  usage: '$0 ' + command + ' package-name -- [opts]',
+  demand: 1,
+  demandDesc: 'you must provide a package to remove'
+}
+
+module.exports = utils.decorate(cmd)

--- a/cmd/reset-follower.js
+++ b/cmd/reset-follower.js
@@ -1,0 +1,8 @@
+var utils = require('../lib/utils')
+
+var cmd = {
+  desc: 'reset the upstream registry follower',
+  epilog: 'reset the sequence # of the upstream registry follower'
+}
+
+module.exports = utils.decorate(cmd, __filename)

--- a/cmd/ssh.js
+++ b/cmd/ssh.js
@@ -1,0 +1,7 @@
+var utils = require('../lib/utils')
+
+var cmd = {
+  desc: 'ssh into the npm Enterprise registry container'
+}
+
+module.exports = utils.decorate(cmd, __filename)

--- a/cmd/update-license.js
+++ b/cmd/update-license.js
@@ -1,0 +1,8 @@
+var utils = require('../lib/utils')
+
+var cmd = {
+  desc: 'update the license associated with your npm Enterprise appliance',
+  epilog: 'update the license on your npm Enterprise appliance'
+}
+
+module.exports = utils.decorate(cmd, __filename)

--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -1,0 +1,8 @@
+var updateNotifier = require('update-notifier')
+var packageJson = require('../package.json')
+
+module.exports = function () {
+  updateNotifier({
+    pkg: packageJson
+  }).notify()
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,54 @@
+var path = require('path')
+var spawn = require('child_process').spawn
+
+var adminCommand = exports.adminCommand = 'replicated admin '
+
+var cwd = exports.cwd = path.resolve(__dirname, '../')
+
+var exec = exports.exec = function (command, sudo, cb) {
+  var commands = ['-c']
+  if (sudo) command = 'sudo -E ' + command
+  commands.push(command)
+
+  var proc = spawn('sh', commands, {
+    cwd: cwd,
+    env: process.env,
+    stdio: 'inherit'
+  })
+
+  proc.on('close', function (code) {
+    cb(code)
+  })
+}
+
+var command = exports.command = function (filename) {
+  return path.basename(filename, path.extname(filename))
+}
+
+var defaultBuilder = exports.defaultBuilder = function (cmd) {
+  return function (yargs) {
+    if (cmd.usage) yargs.usage(cmd.usage)
+    if (cmd.options) yargs.options(cmd.options)
+    if (cmd.demand) {
+      if (cmd.demandDesc) yargs.demand(1 + cmd.demand, cmd.demandDesc)
+      else yargs.demand(1 + cmd.demand)
+    }
+    if (cmd.epilog) yargs.epilog(cmd.epilog)
+    return yargs
+  }
+}
+
+var defaultHandler = exports.defaultHandler = function () {
+  return function (argv) {
+    exec(adminCommand + argv._.join(' '), argv.sudo, function () {})
+  }
+}
+
+exports.decorate = function (cmd, filename) {
+  if (!cmd.command && filename) cmd.command = command(filename)
+  if (!cmd.usage) cmd.usage = '$0 ' + cmd.command + ' [opts]'
+  if (cmd.desc && !cmd.epilog) cmd.epilog = cmd.desc
+  if (!cmd.builder) cmd.builder = defaultBuilder(cmd)
+  if (!cmd.handler) cmd.handler = defaultHandler()
+  return cmd
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "inquirer": "^0.9.0",
     "public-ip": "^1.1.0",
     "request": "^2.61.0",
-    "yargs": "^3.21.0"
+    "yargs": "^4.6.0"
   },
   "devDependencies": {
     "standard": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -19,14 +19,13 @@
   },
   "homepage": "https://www.npmjs.com/enterprise",
   "dependencies": {
-    "chalk": "^1.1.1",
-    "inquirer": "^0.9.0",
-    "public-ip": "^1.1.0",
-    "request": "^2.61.0",
+    "chalk": "^1.1.3",
+    "public-ip": "^1.2.0",
+    "request": "^2.72.0",
     "yargs": "^4.6.0"
   },
   "devDependencies": {
-    "standard": "^5.1.0",
+    "standard": "^6.0.8",
     "standard-version": "^2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chalk": "^1.1.3",
     "public-ip": "^1.2.0",
     "request": "^2.72.0",
+    "update-notifier": "^0.6.3",
     "yargs": "^4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A lot of changes due to refactoring commands into modules. Although the number of files has increased, I think the code duplication has been significantly reduced and command isolation should make for easier testing. With the refactor, I have cleaned up the CLI help text and expectations based on wrapped CLIs.

The new feature added is automatic checks for newer `npme` versions via `update-notifier`. This is gonna help keep the bin up-to-date for folks launching our AMI, so we can continue to build more integration features into `npme` and notify people of updates in a separate distribution channel from appliance releases (which are independent of this bin).

The way that `update-notifier` works is it checks for an update once a day via spawned process when the bin is run. When an update is found, it is stored in `~/.config/configstore/update-notifier-npme.json`, and the next time the bin is run, the user will be notified of an available update, which looks like this:

<img width="627" alt="screen shot 2016-04-27 at 12 04 41 pm" src="https://cloud.githubusercontent.com/assets/1929625/14859546/95f1f58a-0c72-11e6-9b18-fe5f470e08e3.png">

So I think it takes at least 2 runs of the bin to get the notification, once for the initial check and a subsequent run to notify the user.

To fake it for testing, you can modify the version in package.json, modify the timestamp in `~/.config/configstore/update-notifier-npme.json`, and then run the bin a couple times.

A lot of projects use it, so I assume it works well enough for us.

Also took the chance to update other dependencies as well.