### PR TITLE
Do not let update-notifier errors crash the bin

### DIFF
--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -11,7 +11,7 @@ module.exports = function () {
       pkg: packageJson
     })
     notify(notifier, {
-      updateCommand: 'sudo npm i -g',
+      updateCommand: 'sudo npm i -g ',
       borderStyle: 'double-single'
     })
   } catch (_) {}

--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -17,7 +17,15 @@ module.exports = function () {
       updateCommand: 'sudo npm i -g ',
       borderStyle: 'double-single'
     })
-  } catch (_) {}
+  } catch (_) {
+    process.on('exit', function () {
+      var msg = chalk.yellow('                          npme update check failed') +
+        '\n                    Try running as sudo next time, or run:\n' +
+        chalk.cyan(' sudo chown $USER:$(id -gn $USER) ~/.config/configstore/update-notifier-npme.json ') +
+        '\n                to give your user access to the update config'
+      console.error('\n' + boxen(msg))
+    })
+  }
 }
 
 // argh! have to duplicate the UpdateNotifier.notify logic to use a custom message!

--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -2,7 +2,47 @@ var updateNotifier = require('update-notifier')
 var packageJson = require('../package.json')
 
 module.exports = function () {
-  updateNotifier({
-    pkg: packageJson
-  }).notify()
+  // super hacky: skip for autoinstall command
+  if (isNpm || (process.argv.length > 2 && process.argv[2] === 'autoinstall')) return
+
+  // beware file permissions problems b/w sudo and not
+  try {
+    var notifier = updateNotifier({
+      pkg: packageJson
+    })
+    notify(notifier, {
+      updateCommand: 'sudo npm i -g',
+      borderStyle: 'double-single'
+    })
+  } catch (_) {}
+}
+
+// argh! have to duplicate the UpdateNotifier.notify logic to use a custom message!
+var isNpm = require('is-npm')
+var boxen = require('boxen')
+var chalk = require('chalk')
+
+function notify (notifier, opts) {
+  if (!process.stdout.isTTY || isNpm || !notifier.update) {
+    return notifier
+  }
+
+  opts = opts || {}
+
+  var message = '\n' + boxen('Update available ' + chalk.dim(notifier.update.current) + chalk.reset(' → ') + chalk.green(notifier.update.latest) + ' \nRun ' + chalk.cyan((opts.updateCommand || 'npm i -g ') + notifier.packageName) + ' to update', {
+    padding: 1,
+    margin: 1,
+    borderColor: 'yellow',
+    borderStyle: opts.borderStyle || 'round'
+  })
+
+  if (opts.defer === undefined) {
+    process.on('exit', function () {
+      console.error(message)
+    })
+  } else {
+    console.error(message)
+  }
+
+  return notifier
 }

--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -1,5 +1,8 @@
 var updateNotifier = require('update-notifier')
 var packageJson = require('../package.json')
+var isNpm = require('is-npm')
+var boxen = require('boxen')
+var chalk = require('chalk')
 
 module.exports = function () {
   // super hacky: skip for autoinstall command
@@ -18,10 +21,6 @@ module.exports = function () {
 }
 
 // argh! have to duplicate the UpdateNotifier.notify logic to use a custom message!
-var isNpm = require('is-npm')
-var boxen = require('boxen')
-var chalk = require('chalk')
-
 function notify (notifier, opts) {
   if (!process.stdout.isTTY || isNpm || !notifier.update) {
     return notifier

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+var checkForUpdate = require('./check-for-update')
 var path = require('path')
 var spawn = require('child_process').spawn
 
@@ -50,5 +51,12 @@ exports.decorate = function (cmd, filename) {
   if (cmd.desc && !cmd.epilog) cmd.epilog = cmd.desc
   if (!cmd.builder) cmd.builder = defaultBuilder(cmd)
   if (!cmd.handler) cmd.handler = defaultHandler()
+
+  var builder = cmd.builder
+  cmd.builder = function (yargs) {
+    checkForUpdate()
+    return builder(yargs)
+  }
+
   return cmd
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": "bin/npme.js",
   "scripts": {
     "pretest": "standard",
-    "postinstall": "node ./bin/npme.js install",
+    "postinstall": "node ./bin/npme.js autoinstall",
     "release": "standard-version"
   },
   "repository": {
@@ -19,7 +19,9 @@
   },
   "homepage": "https://www.npmjs.com/enterprise",
   "dependencies": {
+    "boxen": "^0.5.1",
     "chalk": "^1.1.3",
+    "is-npm": "^1.0.0",
     "public-ip": "^1.2.0",
     "request": "^2.72.0",
     "update-notifier": "^0.6.3",


### PR DESCRIPTION
Found problem testing 3.7.0 with `update-notifier` file permissions. This is somewhat of an ugly ~~hack~~ fix to handle cases of running the `npme` bin between sudo/root and non-root users.

1. Silently ignore errors (fs permission problems against `~/.config/configstore/update-notifier-npme.json` file) when running `update-notifier`
2. Do not run `update-notifier` on prescribed installation (`sudo npm i -g npme --unsafe`) by using a hidden alias of the `install` command for the `postinstall` script
3. Customize the `update-notifier` update message to say `sudo npm i -g` instead of `npm i -g`

The goal of item 2 is to check for updates when running the bin with valid non-autoinstall command (by decorating each command `builder` function) or with invalid/missing command (via custom yargs failure handler and strict mode).

I have tested this on an existing instance that already had npmo/npme installed, but I still need to test it against a fresh install instance. Will do that via `next` tag after merging this.