### PR TITLE
fix: have to chown -R to fix update-notifier access

### DIFF
--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -19,10 +19,10 @@ module.exports = function () {
     })
   } catch (_) {
     process.on('exit', function () {
-      var msg = chalk.yellow('                          npme update check failed') +
-        '\n                    Try running as sudo next time, or run:\n' +
-        chalk.cyan(' sudo chown $USER:$(id -gn $USER) ~/.config/configstore/update-notifier-npme.json ') +
-        '\n                to give your user access to the update config'
+      var msg = chalk.yellow('           npme update check failed') +
+        '\n    Try running as sudo next time, or run:\n' +
+        chalk.cyan(' sudo chown -R $USER:$(id -gn $USER) ~/.config ') +
+        '\n to give your user access to the update config'
       console.error('\n' + boxen(msg))
     })
   }


### PR DESCRIPTION
Trying to perfect this odd situation when you run `sudo npme` the first time instead of just `npme`.

Now looks like this:

<img width="360" alt="screen shot 2016-04-28 at 2 21 50 pm" src="https://cloud.githubusercontent.com/assets/1929625/14896738/0f1c2270-0d4d-11e6-8086-af47763cf3d8.png">
