### PR TITLE
feat: use replicated bin if present, fall back to docker admin command

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,16 @@
 var checkForUpdate = require('./check-for-update')
 var path = require('path')
 var spawn = require('child_process').spawn
+var which = require('which')
 
-var adminCommand = exports.adminCommand = 'replicated admin '
+var adminCommand = 'replicated admin '
+try {
+  which.sync('replicated')
+} catch (err) {
+  if (err.code === 'ENOENT') adminCommand = 'docker exec -it replicated replicated admin '
+}
+
+exports.adminCommand = adminCommand
 
 var cwd = exports.cwd = path.resolve(__dirname, '../')
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "public-ip": "^1.2.0",
     "request": "^2.72.0",
     "update-notifier": "^0.6.3",
+    "which": "^1.2.9",
     "yargs": "^4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
in prep for switching over to docker-based replicated, this updates our npme admin commands so that they will work on both old versions of replicated (with replicated installed as a bin) and new versions of replicated (with replicated being a bash alias).