### PR TITLE
feat: switch to docker/stable as our default installation

### DIFF
--- a/cmd/install.js
+++ b/cmd/install.js
@@ -13,6 +13,7 @@ var cmd = {
   options: {
     r: {
       alias: 'release',
+      default: 'docker/stable',
       description: 'what release of replicated should be used (defaults to stable)',
       type: 'string'
     }

--- a/cmd/install.js
+++ b/cmd/install.js
@@ -13,7 +13,7 @@ var cmd = {
   options: {
     r: {
       alias: 'release',
-      default: 'docker/stable',
+      default: 'docker',
       description: 'what release of replicated should be used (defaults to stable)',
       type: 'string'
     }

--- a/cmd/install.js
+++ b/cmd/install.js
@@ -33,7 +33,7 @@ cmd.handler = function (argv) {
 
       fs.writeFileSync(path.resolve(cwd, './install.sh'), content, 'utf-8')
 
-      exec('sh install.sh', argv.sudo, function (code) {
+      exec('bash install.sh', argv.sudo, function (code) {
         if (code !== 0) {
           console.log(chalk.bold.red('oh no! something went wrong during the install...\r\n') +
             chalk.bold.red('contact ') +


### PR DESCRIPTION
BREAKING CHANGE: replicated will now run on Docker without a central bin being installed for management