### PR TITLE
feat: cleanup the UI a bit, link to http rather than https

### DIFF
--- a/cmd/install.js
+++ b/cmd/install.js
@@ -1,4 +1,6 @@
 var chalk = require('chalk')
+var boxen = require('boxen')
+var figures = require('figures')
 var fs = require('fs')
 var path = require('path')
 var publicIp = require('public-ip')
@@ -44,27 +46,22 @@ cmd.handler = function (argv) {
             exec('cp -f brand.css /etc/replicated/brand/brand.css', argv.sudo, function () {})
           })
 
-          console.log(chalk.bold.green('Congrats! Your npm Enterprise server is now up and running \\o/'))
-          console.log(chalk.bold('\nThere are just a few final steps:\n'))
-
           publicIp.v4(function (err, ip) {
             var accessMessage
 
             if (err) {
-              accessMessage = 'Access this server in a web-browser via port 8800 (this will bring you to an admin console)'
+              accessMessage = ' Access the admin console in a web-browser via port ' + chalk.bold.cyan(8800)
             } else {
-              accessMessage = 'Access this server in a web-browser at https://' + ip + ':8800 (this will bring you to an admin console)'
+              accessMessage = ' Access the admin console in a web-browser at ' + chalk.bold.cyan('http://' + ip + ':8800')
             }
 
-            ;[
-              accessMessage,
-              'Proceed passed the HTTPS connection security warning (a self-signed cert is being used initially)',
-              'Upload a custom TLS/SSL cert/key or proceed with the provided self-signed pair.',
-              'Configure your npm instance & click "Save".',
-              'Visit https://docs.npmjs.com/, for information about using npm Enterprise or contact support@npmjs.com'
-            ].forEach(function (s, i) {
-              console.log(chalk.bold('Step ' + (i + 1) + '.') + ' ' + s)
-            })
+            console.log(
+              boxen(
+                figures.squareSmall + accessMessage + '\n\n' +
+                figures.tick + ' Visit ' + chalk.bold.cyan('https://docs.npmjs.com/') + ', for information about using npm Enterprise or contact ' + chalk.bold.cyan('support@npmjs.com'),
+                {padding: 1}
+              )
+            )
           })
         }
       })

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "boxen": "^0.5.1",
     "chalk": "^1.1.3",
+    "figures": "^1.7.0",
     "is-npm": "^1.0.0",
     "public-ip": "^1.2.0",
     "request": "^2.72.0",


### PR DESCRIPTION
* switch to `http` from `https` now that replicated shows a tutorial on how to setup SSL.
* make the UI look a bit better based on my walkthrough with Jerry yesterday.

<img width="797" alt="screen shot 2016-06-03 at 5 56 37 pm" src="https://cloud.githubusercontent.com/assets/194609/15796576/d7bf54f8-29b4-11e6-83d3-4075d944e520.png">
