### PR TITLE
fix: use --ignore-scripts in update-notifier message

### DIFF
--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -3,6 +3,7 @@ var packageJson = require('../package.json')
 var isNpm = require('is-npm')
 var boxen = require('boxen')
 var chalk = require('chalk')
+var ansiAlign = require('ansi-align')
 
 module.exports = function () {
   // super hacky: skip for autoinstall command
@@ -14,7 +15,7 @@ module.exports = function () {
       pkg: packageJson
     })
     notify(notifier, {
-      updateCommand: 'sudo npm i -g ',
+      updateCommand: 'sudo npm i -g --ignore-scripts ',
       borderStyle: 'double-single'
     })
   } catch (_) {
@@ -36,12 +37,18 @@ function notify (notifier, opts) {
 
   opts = opts || {}
 
-  var message = '\n' + boxen('Update available ' + chalk.dim(notifier.update.current) + chalk.reset(' → ') + chalk.green(notifier.update.latest) + ' \nRun ' + chalk.cyan((opts.updateCommand || 'npm i -g ') + notifier.packageName) + ' to update', {
-    padding: 1,
-    margin: 1,
-    borderColor: 'yellow',
-    borderStyle: opts.borderStyle || 'round'
-  })
+  var message = '\n' + boxen(
+    ansiAlign(
+      'Update available ' + chalk.dim(notifier.update.current) + chalk.reset(' → ') + chalk.green(notifier.update.latest) +
+      ' \nRun ' + chalk.cyan((opts.updateCommand || 'npm i -g ') + notifier.packageName) + ' to update'
+    ),
+    {
+      padding: 1,
+      margin: 1,
+      borderColor: 'yellow',
+      borderStyle: opts.borderStyle || 'round'
+    }
+  )
 
   if (opts.defer === undefined) {
     process.on('exit', function () {

--- a/lib/check-for-update.js
+++ b/lib/check-for-update.js
@@ -19,11 +19,13 @@ module.exports = function () {
       borderStyle: 'double-single'
     })
   } catch (_) {
+    var msg = ansiAlign(
+      chalk.yellow('npme update check failed') +
+      '\nTry running as sudo next time, or run:\n' +
+      chalk.cyan(' sudo chown -R $USER:$(id -gn $USER) ~/.config ') +
+      '\nto give your user access to the update config'
+    )
     process.on('exit', function () {
-      var msg = chalk.yellow('           npme update check failed') +
-        '\n    Try running as sudo next time, or run:\n' +
-        chalk.cyan(' sudo chown -R $USER:$(id -gn $USER) ~/.config ') +
-        '\n to give your user access to the update config'
       console.error('\n' + boxen(msg))
     })
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://www.npmjs.com/enterprise",
   "dependencies": {
+    "ansi-align": "^1.0.0",
     "boxen": "^0.5.1",
     "chalk": "^1.1.3",
     "figures": "^1.7.0",


### PR DESCRIPTION
I recently noticed our custom `update-notifier` message instructed to update via `sudo npm i -g npme`, but running this fails without either the `--unsafe` flag (to run as root instead of nobody) or the `--ignore-scripts` flag (to bypass the autoinstall run script and just update the bin instead of attempting to upgrade Replicated as well).

Since I don't want to disrupt the running appliance without the user's explicit knowledge/consent, I opted for using `--ignore-scripts`. We could, of course, use a longer message that presents the user with both options, but that might be overkill.

I added the `ansi-align` dependency (same one used by `update-notifier`) to easily center-align the update message in the box.

New update message looks like this:

<img width="447" alt="screen shot 2016-06-06 at 11 03 26 am" src="https://cloud.githubusercontent.com/assets/1929625/15827049/fd9d5330-2bd7-11e6-9bd9-050c01cd3e18.png">
