### PR TITLE
fix: better logic to determine if package spec is versioned

### DIFF
--- a/cmd/add-package.js
+++ b/cmd/add-package.js
@@ -15,7 +15,7 @@ var cmd = {
 
 cmd.handler = function (argv) {
   var cmd = adminCommand + argv._.join(' ')
-  if (~cmd.indexOf('@')) cmd += ' --all-versions=false'
+  if (argv._[1].lastIndexOf('@') > 0) cmd += ' --all-versions=false'
   exec(cmd, argv.sudo, function () {})
 }
 


### PR DESCRIPTION
To support unversioned scoped packages in add-package command.

cc @bcoe 