### PR TITLE
feat: creating script for verifying and fixing registries

### DIFF
--- a/bin/npme.js
+++ b/bin/npme.js
@@ -12,15 +12,7 @@ var yargs = require('yargs')
   .usage('$0 [command] [arguments]')
   .command(install)
   .command('autoinstall', false, install)
-  .command(require('../cmd/ssh'))
-  .command(require('../cmd/add-package'))
-  .command(require('../cmd/remove-package'))
-  .command(require('../cmd/reset-follower'))
-  .command(require('../cmd/update-license'))
-  .command(require('../cmd/manage-tokens'))
-  .command(require('../cmd/edit-homepage'))
-  .command(require('../cmd/addon'))
-  .command(require('../cmd/addon-remove'))
+  .commandDir('../cmd')
   .option('s', {
     alias: 'sudo',
     description: 'should shell commands be run as sudo user',

--- a/cmd/generate-maintenance-cron.js
+++ b/cmd/generate-maintenance-cron.js
@@ -1,0 +1,30 @@
+var chalk = require('chalk')
+var inquirer = require('inquirer')
+var utils = require('../lib/utils')
+var which = require('which')
+var exec = utils.exec
+
+var cmd = {
+  desc: "generate a cront tab line for npme's CouchDB maintenace script"
+}
+
+cmd.handler = function (argv) {
+  const npmeBin = which.sync('npme')
+  inquirer.prompt([
+    {
+      type: 'input',
+      name: 'upstream',
+      message: 'upstream CouchDB server to verify against'
+    },
+    {
+      type: 'input',
+      name: 'local',
+      message: 'local CouchDB server to verify'
+    },
+  ]).then(function (answers) {
+    console.log('add the following to your crontab:')
+    console.log(chalk.green('0\t*\t*\t*\t*\t ' + npmeBin + ' maintenance --upstream=' + answers.upstream + ' --local=' + answers.local))
+  })
+}
+
+module.exports = utils.decorate(cmd, __filename)

--- a/cmd/maintenance.js
+++ b/cmd/maintenance.js
@@ -1,0 +1,26 @@
+var inquirer = require('inquirer')
+var utils = require('../lib/utils')
+var which = require('which')
+var exec = utils.exec
+
+var cmd = {
+  desc: "run maintenance against a CouchDB server (make sure it's packages are up-to-date)"
+}
+
+cmd.builder = function (yargs) {
+  yargs
+    .option('upstream', {
+      describe: 'upstream CouchDB server to verify against',
+      demand: true
+    })
+    .option('local', {
+      describe: 'local CouchDB server to verify',
+      demand: true
+    })
+}
+
+cmd.handler = function (argv) {
+  console.log(argv)
+}
+
+module.exports = utils.decorate(cmd, __filename)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,8 +39,8 @@ var defaultBuilder = exports.defaultBuilder = function (cmd) {
     if (cmd.usage) yargs.usage(cmd.usage)
     if (cmd.options) yargs.options(cmd.options)
     if (cmd.demand) {
-      if (cmd.demandDesc) yargs.demand(1 + cmd.demand, cmd.demandDesc)
-      else yargs.demand(1 + cmd.demand)
+      if (cmd.demandDesc) yargs.demand(cmd.demand, cmd.demandDesc)
+      else yargs.demand(cmd.demand)
     }
     if (cmd.epilog) yargs.epilog(cmd.epilog)
     return yargs

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "boxen": "^0.5.1",
     "chalk": "^1.1.3",
     "figures": "^1.7.0",
+    "inquirer": "^3.0.1",
     "is-npm": "^1.0.0",
     "public-ip": "^1.2.0",
     "request": "^2.72.0",
     "update-notifier": "^0.6.3",
-    "which": "^1.2.9",
-    "yargs": "^4.6.0"
+    "which": "^1.2.12",
+    "yargs": "^7.0.0-alpha.1"
   },
   "devDependencies": {
     "standard": "^6.0.8",


### PR DESCRIPTION
I've stubbed out the two commands for running verify against registries:

* `generate-maintenance-cron`: prints out the text that should be added to a cron.
* `maintenance`: will run the actual verification script.