### PR TITLE
fix: allow sharedFetchSecret to be configured for maintenance script

### DIFF
--- a/bin/npme.js
+++ b/bin/npme.js
@@ -28,14 +28,12 @@ var yargs = require('yargs')
   .strict()
 
 // mimic standard yargs failure handler, but call checkForUpdate()
-yargs.fail(function (msg, err) {
+yargs.fail(function (msg, err) { // eslint-disable-line
   checkForUpdate()
   yargs.showHelp('error')
   console.error(msg)
   process.exit(1)
 }).argv
-
-
 
 process.on('uncaughtException', function (err) {
   // if there is no Internet connection

--- a/cmd/generate-maintenance-cron.js
+++ b/cmd/generate-maintenance-cron.js
@@ -5,7 +5,6 @@ var which = require('which')
 var url = require('url')
 var request = require('request')
 var fs = require('fs')
-var path = require('path')
 
 var cmd = {
   desc: "generate a cron tab line for npme's CouchDB maintenace script"
@@ -14,64 +13,63 @@ var cmd = {
 cmd.handler = function (argv) {
   const npmeBin = which.sync('npme')
 
-  // allow folks to procede after auth failure on scan url. 
+  // allow folks to procede after auth failure on scan url.
   var failedScanValidate = false
   // populated when validating scan url
-  var checkPackageName;
+  var checkPackageName
   // extracted from check hosts metadata for checkPackageName
-  var tarHost;
+  var tarHost
 
   inquirer.prompt([
     {
       type: 'input',
       name: 'scan',
       message: 'we stream all the documents in this database (the replica).',
-      default:'http://admin:admin@172.17.0.1:5984/registry',
-      filter:function(input){
-        if(!failedScanValidate) {
+      default: 'http://admin:admin@172.17.0.1:5984/registry',
+      filter: function (input) {
+        if (!failedScanValidate) {
           input = cleanCheckUrl(input)
         }
         return input
       },
-      validate:function(input){
-
+      validate: function (input) {
         var alreadyFailed = failedScanValidate
         var done = this.async()
-        if(!alreadyFailed){ 
+        if (!alreadyFailed) {
           input = cleanCheckUrl(input)
         }
 
-        process.stdout.write('  ...checking '+input)
+        process.stdout.write('  ...checking ' + input)
 
-        request.get(input+'/_changes'+"?start=1&limit=20",function(err,res,body){
-          if(err) {
-            return done(err+'')
+        request.get(input + '/_changes' + '?start=1&limit=20', function (err, res, body) {
+          if (err) {
+            return done(err + '')
           }
-          var reso = json(body)||{}
+          var reso = json(body) || {}
           // 404. the database specified in the url doesnt exist.
           // 400. _changes is not a valid db name. this means they did not specify a url
 
-          if(reso.error || res.statusCode !== 200) {
-            var message = reso.error||'';
-            if(res.statusCode === 404) {
+          if (reso.error || res.statusCode !== 200) {
+            var message = reso.error || ''
+            if (res.statusCode === 404) {
               message += '\ncould not find the database name specified by the url.'
             } else if (res.statusCode === 401) {
               // This flag is set here to allow someone to submit credentials that dont have write access.
               // they have to type them twice but this allows folks to generate the command and figure it out later.
               // also makes it possible to test generating on replicate.npmjs.com =P
               failedScanValidate = true
-              message += '\nincorrect username and password provided. please replace '+url.parse(input).auth+' in the url.'
+              message += '\nincorrect username and password provided. please replace ' + url.parse(input).auth + ' in the url.'
             }
 
-            message += '\nplease copy and update this value: '+chalk.yellow(url.resolve(input,'/registry'))
-            
-            if(alreadyFailed){
+            message += '\nplease copy and update this value: ' + chalk.yellow(url.resolve(input, '/registry'))
+
+            if (alreadyFailed) {
               console.log(chalk.yellow('Warning. could not verify scan url.'))
-              done(false,true)
+              done(false, true)
             } else {
-              done(message,false)
+              done(message, false)
             }
-            return;
+            return
           }
 
           // also we hit this to gather a package name to check to validate the:
@@ -85,19 +83,19 @@ cmd.handler = function (argv) {
           var notDesign
           var unscoped
 
-          (reso.results||[]).forEach(function(r){
-            var id = r.id||''
-            if(id.length && id.indexOf('_') !== 0) {
+          (reso.results || []).forEach(function (r) {
+            var id = r.id || ''
+            if (id.length && id.indexOf('_') !== 0) {
               notDesign = id
-              if(id.indexOf('@') === -1) {
+              if (id.indexOf('@') === -1) {
                 unscoped = id
               }
             }
           })
 
-          checkPackageName = unscoped||notDesign
+          checkPackageName = unscoped || notDesign
 
-          done(false,true)
+          done(false, true)
         })
       }
     },
@@ -105,28 +103,28 @@ cmd.handler = function (argv) {
       type: 'input',
       name: 'check',
       message: 'we request each doc in the stream from scan to see if check has the same versions (the primary)',
-      validate:function(input){
+      validate: function (input) {
         var parsed = url.parse(input)
-        if(!parsed.hostname && parsed.protocol) {
+        if (!parsed.hostname && parsed.protocol) {
           console.log('\na url is required.')
           return false
         }
 
         var done = this.async()
-        request.get(url.resolve(input,'/'+checkPackageName),function(err,res,body){
-          if(err) { 
-            return done(err+'')
-          } else if(res.statusCode === 200) {
+        request.get(url.resolve(input, '/' + checkPackageName), function (err, res, body) {
+          if (err) {
+            return done(err + '')
+          } else if (res.statusCode === 200) {
             var checkPackageMetadata = json(body)
-            var versions = checkPackageMetadata.versions||{}
-            var dist = Object.keys(versions)[0]||{}.dist
-            if(dist.tarball){
-              var parsed = url.parse(dist).host           
-              tarHost = parsed.protocol+'//'+parsed.host
+            var versions = checkPackageMetadata.versions || {}
+            var dist = Object.keys(versions)[0] || {}.dist
+            if (dist.tarball) {
+              var parsed = url.parse(dist).host
+              tarHost = parsed.protocol + '//' + parsed.host
             }
           }
 
-          done(false,true)
+          done(false, true)
         })
       }
     },
@@ -135,33 +133,33 @@ cmd.handler = function (argv) {
       name: 'data-directory',
       message: 'data directory to store missing tarballs',
       default: '/usr/local/lib/npme/packages',
-      validate:function(input){
+      validate: function (input) {
         // so it's bad if they repair their instance to the wrong data dir.
         // because versions will exist but tarballs wont.
         var done = this.async()
 
-        fs.readdir(input,function(err,files){
-          done(err,files?true:false)
+        fs.readdir(input, function (err, files) {
+          done(err, !!files)
         })
       }
     },
     {
-      type:'input',
-      name:'tarhost',
-      message:'the host that has the missing tarballs. defaults to check url host.',
-      //'If the tarball urls have been rewritten to point to a load balancer that includes the replica you are repairing you may need to provide this. otherwise leave it blank.',
-      default:function(answers){
-        return tarHost||answers.check
+      type: 'input',
+      name: 'tarhost',
+      message: 'the host that has the missing tarballs. defaults to check url host.',
+      // 'If the tarball urls have been rewritten to point to a load balancer that includes the replica you are repairing you may need to provide this. otherwise leave it blank.',
+      default: function (answers) {
+        return tarHost || answers.check
       },
-      validate:function(input){
+      validate: function (input) {
         var o = url.parse(input)
-        if(!o || !o.protocol || !o.host) {
+        if (!o || !o.protocol || !o.host) {
           return 'please provide a valid url'
         }
         var done = this.async()
-        process.stdout.write(".. attempting to contact "+input)
-        request.get(input,function(err){
-          done(err,err?false:true)
+        process.stdout.write('.. attempting to contact ' + input)
+        request.get(input, function (err) {
+          done(err, !err)
         })
       }
     }
@@ -170,65 +168,64 @@ cmd.handler = function (argv) {
     done(answers)
   })
 
+  function done (answers) {
+    canCouchdb(answers, function (err, can) {
+      if (err) {
+        console.error(err)
+      }
 
-  function done(answers){ 
-    canCouchdb(answers,function(err,can){
-      //console.log(answers)
-
-      if(!can) {
+      if (!can) {
         console.log('\nerrors verifying your configuration. the generated command may not work :(\n')
       }
 
       var cmd = npmeBin + ' maintenance --check=' + answers.check + ' --scan=' + answers.scan + ' --data-directory=' + answers['data-directory']
 
-      if(answers.tarhost){
-        cmd += " --tar-host="+answers.tarhost
+      if (answers.tarhost) {
+        cmd += ' --tar-host=' + answers.tarhost
       }
 
       console.log('please test the command now by performing a "dry run". run:')
-      console.log(chalk.green(cmd+' --dry-run')+'\n')
+      console.log(chalk.green(cmd + ' --dry-run') + '\n')
 
       console.log('if you prefer to run this manually. run:')
-      console.log(chalk.green(cmd)+'\n')
+      console.log(chalk.green(cmd) + '\n')
 
       console.log('if all that looks fine add the following to your crontab:')
-      console.log(chalk.green('0 * * * * ' + cmd+" 1> "+ answers['data-directory']+"/maintenance.log 2>&1")) 
+      console.log(chalk.green('0 * * * * ' + cmd + ' 1> ' + answers['data-directory'] + '/maintenance.log 2>&1'))
     })
   }
 }
 
-function cleanCheckUrl(check){
+function cleanCheckUrl (check) {
   var parsed = url.parse(check)
-  if(parsed.pathname === '/') {
+  if (parsed.pathname === '/') {
     console.log('\nno database specified in path of scan url. choosing "registry"')
     parsed.pathname = '/registry'
   }
 
-  if(!parsed.auth) {
-    parsed.auth = 'admin:admin' 
+  if (!parsed.auth) {
+    parsed.auth = 'admin:admin'
   }
 
   return url.format(parsed)
 }
 
-function canCouchdb(answers,cb){
-  request.get(url.resolve(answers.scan,'/_active_tasks'),function(err,res,body){
-    if(err){
-      console.log('ERROR: scan\n could not request check couchdb:\n'+err)
-    } else if(res.statusCode != 200){
-      console.log('Warning: scan\n could not verify write permission to couchdb. '+res.statusCode)
+function canCouchdb (answers, cb) {
+  request.get(url.resolve(answers.scan, '/_active_tasks'), function (err, res, body) {
+    if (err) {
+      console.log('ERROR: scan\n could not request check couchdb:\n' + err)
+    } else if (res.statusCode !== 200) {
+      console.log('Warning: scan\n could not verify write permission to couchdb. ' + res.statusCode)
     }
-  
-    cb(false,(err||res.statusCode === 200)?false:true)
 
+    cb(false, !((err || res.statusCode === 200)))
   })
 }
 
-function json(s){
-  try{
+function json (s) {
+  try {
     return JSON.parse(s)
-  } catch(e){}
+  } catch (e) {}
 }
-
 
 module.exports = utils.decorate(cmd, __filename)

--- a/cmd/install.js
+++ b/cmd/install.js
@@ -32,7 +32,7 @@ var cmd = {
     e: {
       alias: 'external-address',
       description: 'the public facing ip address for the server',
-      type: 'string' 
+      type: 'string'
     },
     p: {
       alias: 'http-proxy',
@@ -59,27 +59,27 @@ cmd.handler = function (argv) {
 
       fs.writeFileSync(path.resolve(cwd, './install.sh'), content, 'utf-8')
       var commandSegments = [ 'bash', 'install.sh' ]
-      if( argv.u ) {
-        commandSegments.push( 'bypass-storagedriver-warnings' )
-        if( !argv.p ) {
-          commandSegments.push( 'no-proxy' )
+      if (argv.u) {
+        commandSegments.push('bypass-storagedriver-warnings')
+        if (!argv.p) {
+          commandSegments.push('no-proxy')
         }
       }
-      if( argv.e ) {
-        commandSegments.push( 'public-address=' + argv.e )
+      if (argv.e) {
+        commandSegments.push('public-address=' + argv.e)
       }
-      if( argv.i ) {
-        commandSegments.push( 'private-address=' + argv.i )
+      if (argv.i) {
+        commandSegments.push('private-address=' + argv.i)
       }
-      if( argv.d ) {
-        commandSegments.push( 'docker-version=' + argv.d )
+      if (argv.d) {
+        commandSegments.push('docker-version=' + argv.d)
       }
-      if( argv.p ) {
-        commandSegments.push( 'http-proxy=' + argv.p )
+      if (argv.p) {
+        commandSegments.push('http-proxy=' + argv.p)
       }
-      var commandLine = commandSegments.join( ' ' )
-      
-      exec( commandLine, argv.sudo, function (code) {
+      var commandLine = commandSegments.join(' ')
+
+      exec(commandLine, argv.sudo, function (code) {
         if (code !== 0) {
           console.log(chalk.bold.red('oh no! something went wrong during the install...\r\n') +
             chalk.bold.red('contact ') +

--- a/cmd/maintenance.js
+++ b/cmd/maintenance.js
@@ -27,7 +27,7 @@ cmd.builder = function (yargs) {
       describe: 'only print packages that are missing versions instead of attempting to repair them',
       default: false
     })
-    .option('shared-fetch-secret',{
+    .option('shared-fetch-secret', {
       describe: 'secret to populate when interacting with primary server.'
     })
 }

--- a/cmd/maintenance.js
+++ b/cmd/maintenance.js
@@ -27,10 +27,9 @@ cmd.builder = function (yargs) {
       describe: 'only print packages that are missing versions instead of attempting to repair them',
       default: false
     })
-    // .option('ignore-404',{
-    //  describe:"you may want to update the document with new versions even if the tarball cannot be found.",
-    //  default: false
-    // })
+    .option('shared-fetch-secret',{
+      describe: 'secret to populate when interacting with primary server.'
+    })
 }
 
 cmd.handler = function (argv) {
@@ -58,7 +57,8 @@ cmd.handler = function (argv) {
       currentDoc: data.check,
       versions: data.versions,
       tarHost: argv.tarHost,
-      dataDirectory: argv.dataDirectory
+      dataDirectory: argv.dataDirectory,
+      sharedFetchSecret: argv.sharedFetchSecret
     }, function (err, data) {
       if (err) {
         message += '\terror. ' + err
@@ -72,7 +72,8 @@ cmd.handler = function (argv) {
     })
   }, {
     check: argv.check,
-    scan: argv.scan
+    scan: argv.scan,
+    sharedFetchSecret: argv.sharedFetchSecret
   })
 
   setInterval(function () {

--- a/lib/download-tar.js
+++ b/lib/download-tar.js
@@ -7,7 +7,7 @@ var mis = require('mississippi')
 var once = require('once')
 var crypto = require('crypto')
 
-module.exports = function (name, tarball, shasum, dir, cb) {
+module.exports = function (name, tarball, shasum, dir, sharedFetchSecret, cb) {
   cb = once(cb)
 
   var basename = path.basename(tarball)
@@ -17,13 +17,13 @@ module.exports = function (name, tarball, shasum, dir, cb) {
   fs.exists(targetName, function (exists) {
     if (exists) return cb(false, tarball)
 
-    reallyDownload(tarball, targetDir, targetName, shasum, function (err) {
+    reallyDownload(tarball, targetDir, targetName, shasum, sharedFetchSecret, function (err) {
       cb(err, tarball)
     })
   })
 }
 
-function reallyDownload (tarUrl, targetDir, targetName, shasum, cb) {
+function reallyDownload (tarUrl, targetDir, targetName, shasum, sharedFetchSecret, cb) {
   mkdirp(targetDir, function (err) {
     if (err) return cb(err)
 
@@ -32,6 +32,12 @@ function reallyDownload (tarUrl, targetDir, targetName, shasum, cb) {
     var responded = false
 
     var hash = crypto.createHash('sha1')
+
+    var opts = {
+      method: 'GET',
+      url: tarUrl
+    }
+    if (sharedFetchSecret) opts.qs = { sharedFetchSecret: sharedFetchSecret }
 
     var req = request(tarUrl)
     req.on('response', function (res) {

--- a/lib/replication-check.js
+++ b/lib/replication-check.js
@@ -37,7 +37,7 @@ module.exports = function (handler, config) {
       stream.end()
     }
 
-    doc.name = doc.name||doc._id
+    doc.name = doc.name || doc._id
 
     fetchPackage(config.check, doc.name, config.sharedFetchSecret, function (err, checkDoc) {
       var output = {
@@ -168,9 +168,9 @@ function updateSeq (db, cb) {
 module.exports.fetchPackage = fetchPackage
 
 function fetchPackage (db, name, sharedFetchSecret, cb) {
-  var opts = {url: db + '/' + (name||'').replace('/', '%2f'), timeout: 10000}
+  var opts = {url: db + '/' + (name || '').replace('/', '%2f'), timeout: 10000}
   if (sharedFetchSecret) opts.qs = { sharedFetchSecret: sharedFetchSecret }
-  request(qs, function (err, res, body) {
+  request(opts, function (err, res, body) {
     if (err) return cb(err)
     if (res.statusCode !== 200) {
       var e = new Error('status code ' + res.statusCode)

--- a/lib/replication-check.js
+++ b/lib/replication-check.js
@@ -39,7 +39,7 @@ module.exports = function (handler, config) {
 
     doc.name = doc.name||doc._id
 
-    fetchPackage(config.check, doc.name, function (err, checkDoc) {
+    fetchPackage(config.check, doc.name, config.sharedFetchSecret, function (err, checkDoc) {
       var output = {
         name: doc.name,
         versions: [],
@@ -100,6 +100,7 @@ module.exports.repairVersions = function (options, cb) {
   var tarHost = options.tarHost
   var ignore404 = options.ignore404
   var dataDir = options.dataDirectory
+  var sharedFetchSecret = options.sharedFetchSecret
 
   if (!versions.length) return cb()
 
@@ -128,7 +129,7 @@ module.exports.repairVersions = function (options, cb) {
     }
 
     retry(function (done) {
-      downloadTar(checkDoc.name, tarball, shasum, dataDir, done)
+      downloadTar(checkDoc.name, tarball, shasum, dataDir, sharedFetchSecret, done)
     }, 4, function (err, data) {
       // if the tarball gets a 404 after retries im going to consider this not an error
       finished(err, data)
@@ -166,8 +167,10 @@ function updateSeq (db, cb) {
 
 module.exports.fetchPackage = fetchPackage
 
-function fetchPackage (db, name, cb) {
-  request({url: db + '/' + (name||'').replace('/', '%2f'), timeout: 10000}, function (err, res, body) {
+function fetchPackage (db, name, sharedFetchSecret, cb) {
+  var opts = {url: db + '/' + (name||'').replace('/', '%2f'), timeout: 10000}
+  if (sharedFetchSecret) opts.qs = { sharedFetchSecret: sharedFetchSecret }
+  request(qs, function (err, res, body) {
     if (err) return cb(err)
     if (res.statusCode !== 200) {
       var e = new Error('status code ' + res.statusCode)


### PR DESCRIPTION
we now allow sharedFetchSecret to be configured, so that configurations that authenticate reads can still easily run the maintenance cron.