### PR TITLE
feat: add usage command

### DIFF
--- a/cmd/usage.js
+++ b/cmd/usage.js
@@ -1,0 +1,11 @@
+var utils = require('../lib/utils')
+
+var command = utils.command(__filename)
+
+var cmd = {
+  command: command,
+  desc: 'report npme usage information',
+  usage: '$0',
+}
+
+module.exports = utils.decorate(cmd)


### PR DESCRIPTION
the usage command runs [npme-usage-api](https://github.com/npm/npme-usage-cli) through replicated's admin command functionality, reporting users who have published or installed to an npme instance using an auth token in the past 3-months.

<img width="785" alt="screen shot 2017-09-21 at 5 30 14 pm" src="https://user-images.githubusercontent.com/194609/30724475-da203384-9ef2-11e7-8154-fbb45754b466.png">

see also: https://github.com/npm/npme-docker/pull/125, https://github.com/npm/npme-usage-cli